### PR TITLE
Changes to checkbox indeterminate state

### DIFF
--- a/src/components/buttons/Buttons.tsx
+++ b/src/components/buttons/Buttons.tsx
@@ -7,7 +7,7 @@ type HTMLDivProps = React.DetailedHTMLProps<
   HTMLDivElement
 >;
 
-interface IProps extends ButtonProps {
+export interface IButtonProps extends ButtonProps {
   iconLeft?: any;
   iconRight?: any;
   iconOnly?: any;
@@ -20,7 +20,7 @@ export const PrimaryButton = ({
   iconOnly,
   children,
   ...rest
-}: IProps) => {
+}: IButtonProps) => {
   let cmp;
 
   if (iconLeft) {
@@ -69,7 +69,7 @@ export const SecondaryButton = ({
   iconOnly,
   children,
   ...rest
-}: IProps) => {
+}: IButtonProps) => {
   let cmp;
 
   if (iconLeft) {
@@ -142,7 +142,7 @@ export const FlatButton = ({
   iconOnly,
   children,
   ...rest
-}: IProps) => {
+}: IButtonProps) => {
   let cmp;
 
   if (iconLeft) {

--- a/src/components/inputs/Checkbox.tsx
+++ b/src/components/inputs/Checkbox.tsx
@@ -1,8 +1,8 @@
-import { NrcsCustomInputProps } from "components/types/types";
-import { useRef, useEffect } from "react";
+import { INrcsCustomInputProps } from "components/types/types";
+import React, { useRef, useEffect } from "react";
 import { CustomInput } from "reactstrap";
 
-export interface ICheckboxProps extends NrcsCustomInputProps {}
+export interface ICheckboxProps extends INrcsCustomInputProps {}
 export const Checkbox = ({ indeterminate, type, ...rest }: ICheckboxProps) => {
   const checkboxRef = useRef(null);
   useEffect(() => {

--- a/src/components/inputs/Checkbox.tsx
+++ b/src/components/inputs/Checkbox.tsx
@@ -1,11 +1,9 @@
-import React, { useRef, useEffect } from "react";
-import { CustomInput, CustomInputProps } from "reactstrap";
+import { NrcsCustomInputProps } from "components/types/types";
+import { useRef, useEffect } from "react";
+import { CustomInput } from "reactstrap";
 
-export const Checkbox = ({
-  indeterminate,
-  type,
-  ...rest
-}: CustomInputProps) => {
+export interface ICheckboxProps extends NrcsCustomInputProps {}
+export const Checkbox = ({ indeterminate, type, ...rest }: ICheckboxProps) => {
   const checkboxRef = useRef(null);
   useEffect(() => {
     if (checkboxRef.current) {

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -1,0 +1,15 @@
+import { CSSModule } from "reactstrap";
+
+export interface NrcsCustomInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id"> {
+  [key: string]: any;
+  id: string | number;
+  label?: React.ReactNode;
+  inline?: boolean;
+  valid?: boolean;
+  invalid?: boolean;
+  bsSize?: "lg" | "sm";
+  htmlFor?: string;
+  cssModule?: CSSModule;
+  innerRef?: React.Ref<HTMLElement>;
+}

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -1,6 +1,6 @@
 import { CSSModule } from "reactstrap";
 
-export interface NrcsCustomInputProps
+export interface INrcsCustomInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "id"> {
   [key: string]: any;
   id: string | number;


### PR DESCRIPTION
- Added property interfaces for Checkbox and Button components.
- INrcsCustomInputProps interface is a representation of CustomInputProps interface from reactstrap without "type" key. The reason why this interface was created is because omitting the "type" key from the CustomInputProps interface did not work with OMIT because we have **[key: string]: any**
